### PR TITLE
Bible state restore, intent filter and share button

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,8 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-            <!-- Automatically load on desktop website -->
+
+            <!-- Automatically load office from website -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -44,6 +45,18 @@
                 <data android:host="www.aelf.org" />
                 <data android:path="/" />
                 <data android:pathPrefix="/20" />
+            </intent-filter>
+
+            <!-- Automatically load bible from website -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="www.aelf.org" />
+                <data android:path="/" />
+                <data android:pathPrefix="/bible" />
             </intent-filter>
 
         </activity>

--- a/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
@@ -106,8 +106,12 @@ public class SectionBibleFragment extends SectionFragmentBase {
         // Enable Dom Storage https://stackoverflow.com/questions/33079762/android-webview-uncaught-typeerror-cannot-read-property-getitem-of-null
         webSettings.setDomStorageEnabled(true);
 
-        // Use local resource
-        mWebView.loadUrl("file:///android_asset/www/index.html");
+        // Load webview
+        if (savedInstanceState == null) {
+            mWebView.loadUrl("file:///android_asset/www/index.html");
+        } else {
+            mWebView.restoreState(savedInstanceState);
+        }
         return view;
     }
 
@@ -156,6 +160,14 @@ public class SectionBibleFragment extends SectionFragmentBase {
         }
 
         activity.setRequestedOrientation(activityRequestedOrientation);
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (mWebView != null) {
+            mWebView.saveState(outState);
+        }
     }
 
     // TODO : Fix shadow on "Autres Livres" dropdown menu not showing on real phone

--- a/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
@@ -1,14 +1,21 @@
 package co.epitre.aelf_lectures;
 
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.support.v4.app.FragmentActivity;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 // WebView dependencies
@@ -21,8 +28,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 
-import co.epitre.aelf_lectures.data.AelfDate;
-import co.epitre.aelf_lectures.data.LecturesController;
 
 /**
  * Created by jean-tiare on 12/03/18.
@@ -30,6 +35,7 @@ import co.epitre.aelf_lectures.data.LecturesController;
 
 public class SectionBibleFragment extends SectionFragmentBase {
     public static final String TAG = "SectionBibleFragment";
+    public static final String BASE_RES_URL = "file:///android_asset/www/";
 
     public SectionBibleFragment(){
         // Required empty public constructor
@@ -118,7 +124,7 @@ public class SectionBibleFragment extends SectionFragmentBase {
             mWebView.restoreState(savedInstanceState);
         } else {
             // Load default page
-            mWebView.loadUrl("file:///android_asset/www/index.html");
+            mWebView.loadUrl(BASE_RES_URL + "index.html");
         }
         return view;
     }
@@ -162,12 +168,74 @@ public class SectionBibleFragment extends SectionFragmentBase {
         }
 
         // Load requested page
-        mWebView.loadUrl("file:///android_asset/www/" + parsedUrl);
+        mWebView.loadUrl(BASE_RES_URL + parsedUrl);
     }
 
-    /**
-     * Lifecycle
-     */
+    //
+    // Option menu
+    //
+
+    @Override
+    public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+
+        // Inflate the menu; this adds items to the action bar
+        inflater.inflate(R.menu.toolbar_bible, menu);
+
+        // Make the share image white
+        Drawable normalDrawable = ContextCompat.getDrawable(activity, R.drawable.ic_share_black_24dp);
+        Drawable wrapDrawable = DrawableCompat.wrap(normalDrawable);
+        DrawableCompat.setTint(wrapDrawable, ContextCompat.getColor(activity, R.color.white));
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.action_share:
+                return onShare();
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    //
+    // Events
+    //
+
+    public boolean onShare() {
+        if (mWebView == null) {
+            return false;
+        }
+
+        // Get current webview URL
+        String webviewUrl = mWebView.getUrl();
+        webviewUrl = webviewUrl.substring(BASE_RES_URL.length() - 1, webviewUrl.length()- ".html".length());
+        if (webviewUrl.equals("/index")) {
+            webviewUrl = "/bible";
+        }
+
+        // Get current webview title
+        String webviewTitle = mWebView.getTitle();
+
+        // Build share message
+        String websiteUrl = "https://www.aelf.org" + webviewUrl;
+        String message = webviewTitle + ": " + websiteUrl;
+        String subject = webviewTitle;
+
+        // Create the intent
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, message);
+        intent.putExtra(Intent.EXTRA_SUBJECT, subject);
+        startActivity(Intent.createChooser(intent, getString(R.string.action_share)));
+
+        // All done !
+        return true;
+    }
+
+    //
+    // Lifecycle
+    //
+
     @Override
     public void onResume() {
         super.onResume();

--- a/app/src/main/res/menu/toolbar_bible.xml
+++ b/app/src/main/res/menu/toolbar_bible.xml
@@ -1,0 +1,13 @@
+<menu xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".LecturesActivity">
+
+    <item
+        android:id="@+id/action_share"
+        android:title="@string/action_share"
+        android:orderInCategory="130"
+        android:icon="@drawable/ic_share_black_24dp"
+        app:showAsAction="ifRoom" />
+
+</menu>


### PR DESCRIPTION
Voici les améliorations suivantes pour la partie "Bible":

* Restauration de l'état lorsque l'application est détruite par Android puis rechargée. Concrètement, l'application se ré-ouvre sur le chapitre en cours de lecture avec l'état de retour en arrière associé.
* Ajout d'un "Intent filter". Lorsque qu'un utilisateur va sur la Bible sur le site d'AELF ou reçoit un lien vers la Bible, il a la possibilité de l'ouvrir dans l'application.
* Ajout d'un bouton de partage (rudimentaire) sur le même principe que celui coté Offices. Et comme il y a le "Intent filter", les liens reçus par ce biais peuvent être ouverts directement dans l'application :)

Je commence à regarder pour mettre en place une navigation via le bouton de retour en arrière (https://developer.android.com/training/implementing-navigation/temporal#java). C'est un peu moins simple à mettre en place que cela en a l'air car l'état semble perdu entre 2 actions.

Si cela te convient, je te laisse commenter et / ou merger :)