### PR TITLE
Bump version to 1.9.0-b4

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="co.epitre.aelf_lectures"
     android:installLocation="auto"
-    android:versionCode="48"
+    android:versionCode="49"
     android:versionName="@string/app_version" >
 
     <!-- Required for fetching feed data. -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE resources [
     <!ENTITY app_name    "AELF - Lectures du jour">
-    <!ENTITY app_version "1.9.0-b3">
+    <!ENTITY app_version "1.9.0-b4">
     <!ENTITY app_support "support@epitre.co">
 ]>
 <resources>


### PR DESCRIPTION
Hopefully, this is the last one before the final release!

Changes since Beta 3:

- Bible reading position remembering
- Bible pinch to zoom
- Bible CSS tweaks
- Bible share button
- Bible intent filter (automatically open aelf.org URLs in the application)
- Android dependencies and target version upgrade

Bugs fixed since Beta 3

- Flickering when loading the Bible with the night theme
- Broken landscape mode in the Bible (disabled)
- Bible typos and encoding issues