### PR TITLE
fix samsung screen flicker

### DIFF
--- a/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
@@ -59,7 +59,6 @@ public class LecturesActivity extends AppCompatActivity implements
      * Gesture detector. Detect single taps that do not look like a dismiss to toggle
      * full screen mode.
      */
-    private boolean isFocused = true;
     private boolean isFullScreen = true;
     private boolean isMultiWindow = false;
     private boolean isInLongPress = false;
@@ -302,6 +301,9 @@ public class LecturesActivity extends AppCompatActivity implements
         } else {
             setSection(new SectionOfficesFragment());
         }
+
+        // Setup the (full) screen
+        prepare_fullscreen();
     }
 
     private void restoreSection() {
@@ -343,7 +345,7 @@ public class LecturesActivity extends AppCompatActivity implements
         Window window = getWindow();
 
         // Fullscreen does not make sense when in multi-window mode
-        boolean doFullScreen = isFullScreen && !isMultiWindow && isFocused;
+        boolean doFullScreen = isFullScreen && !isMultiWindow;
 
         // Some users wants complete full screen, no status bar at all. This is NOT compatible with multiwindow mode / non focused
         boolean hideStatusBar = settings.getBoolean(SyncPrefActivity.KEY_PREF_DISP_FULLSCREEN, false) && !isMultiWindow;
@@ -431,10 +433,11 @@ public class LecturesActivity extends AppCompatActivity implements
         // manage application's intrusiveness for different Android versions
         super.onWindowFocusChanged(hasFocus);
 
-        // Always pretend we are going fullscreen. This limits flickering considerably
-        isFullScreen = hasFocus;
-        isFocused = hasFocus;
-        prepare_fullscreen();
+        // If we are gaining the focus, go fullscreen
+        if (hasFocus) {
+            isFullScreen = true;
+            prepare_fullscreen();
+        }
     }
 
     @Override


### PR DESCRIPTION
I had a couple of reports that the application flickers when it is going
fullscreen. What happens is:

1. The application is going fullscreen
2. Android / Samsung displays a message
3. The application looses focus
4. The application moves out of fullscreen
5. Android then removes the fullscreen help message
6. The application gains back the focus
7. The application moves back to fullscreen

This only occurs in portrait mode. A workaround is then to switch to
landscape mode, validate the help message and going back to portrait.