### PR TITLE
Fix share links

### DIFF
--- a/app/src/main/java/co/epitre/aelf_lectures/SectionOfficesFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionOfficesFragment.java
@@ -423,7 +423,7 @@ public class SectionOfficesFragment extends SectionFragmentBase implements
         LectureItem lecture = lecturesPagerAdapter.getLecture(position);
 
         // Build URL
-        String url = "http://www.aelf.org/"+whatwhen.when.toIsoString()+"/romain/"+whatwhen.what.urlName();
+        String url = "http://www.aelf.org/"+whatwhen.when.toIsoString()+"/romain/"+whatwhen.what.aelfUrlName();
         if (lecture.key != null) {
             url += "#"+lecture.key;
         }

--- a/app/src/main/java/co/epitre/aelf_lectures/data/LecturesController.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/data/LecturesController.java
@@ -69,8 +69,9 @@ public final class LecturesController {
         }
 
         public String aelfUrlName() {
+            // There is no specific page for the informations, link to the mass
             if(this.position == 8) {
-                return "informations";
+                return "messe";
             }
             return this.name.split("_")[1];
         }

--- a/app/src/main/java/co/epitre/aelf_lectures/data/LecturesController.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/data/LecturesController.java
@@ -68,6 +68,13 @@ public final class LecturesController {
             return this.name.split("_")[1];
         }
 
+        public String aelfUrlName() {
+            if(this.position == 8) {
+                return "informations";
+            }
+            return this.name.split("_")[1];
+        }
+
         public String actionBarName() {
             if(this.position == 6) {
                 return "Vêpres";


### PR DESCRIPTION
The sharing links for the mass and the information offices were both broken. The link for the mass should be "messe" rather than "messes" while the link to the "information" should target an existing page...