### PR TITLE
Jt highlight current verse

### DIFF
--- a/app/src/main/java/co/epitre/aelf_lectures/LectureFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LectureFragment.java
@@ -248,8 +248,9 @@ public class LectureFragment extends Fragment implements
                         "   display: none;" + // quick and dirty fix for spurious images. May need to be removed / hacked
                         "}" +
                         ".antienne-title {" + // antienne
-                        "    color: "+color_text_accent+";" +
+                        "   color: "+color_text_accent+";" +
                         "   font-style: italic;" +
+                        "   font-weight: bold;" +
                         "} " +
                         "</style>" +
                     "</head>" +

--- a/app/src/main/java/co/epitre/aelf_lectures/LectureFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LectureFragment.java
@@ -226,6 +226,18 @@ public class LectureFragment extends Fragment implements
                         "   display: block;" +
                         "   margin-bottom: 5px;" +
                         "}" +
+                        // Highlight the current position in the lecture. This is hint for the user
+                        ":focus {" +
+                        "    outline: none;" +
+                        "    border-left: 2px "+color_text_accent+" solid;" +
+                        "    margin-left: -4px;" +
+                        "}" +
+                        ".line:focus, div.antienne:focus {" +
+                        "    padding-left: 2px;" +
+                        "}" +
+                        ".line-wrap:focus {" +
+                        "    padding-left: 27px;" +
+                        "}" +
                         ".line-wrap {" +
                         "   display: block;" +
                         "   padding-left: 25px;" +

--- a/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
@@ -109,11 +109,8 @@ public class LecturesActivity extends AppCompatActivity implements
         Boolean nightMode = settings.getBoolean(SyncPrefActivity.KEY_PREF_DISP_NIGHT_MODE, false);
         this.setTheme(nightMode ? R.style.AelfAppThemeDark : R.style.AelfAppThemeLight);
 
-        // Do not restore any state/cache beyond what we explicitely control as an attempt to fix
-        // spurious display of psalms in "hymnes" for instance on restore days after.
-        // https://stackoverflow.com/questions/15519214/prevent-fragment-recovery-in-android
-        // super.onCreate(createBundleNoFragmentRestore(savedInstanceState));
-        super.onCreate(createBundleNoFragmentRestore(savedInstanceState));
+        // Restore state
+        super.onCreate(savedInstanceState);
 
         // ---- need upgrade ?
         int currentVersion, savedVersion;
@@ -316,15 +313,6 @@ public class LecturesActivity extends AppCompatActivity implements
         FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
         fragmentTransaction.replace(R.id.section_container, sectionFragment);
         fragmentTransaction.commit();
-    }
-
-    private static Bundle createBundleNoFragmentRestore(Bundle bundle) {
-        if (bundle != null) {
-            // Sometime, when restoring, the displayed toolbar_main are not consistent with the displayed
-            // date / office. This is a bug in the restore code.
-            // bundle.remove("android:support:fragments");
-        }
-        return bundle;
     }
 
     protected int get_status_bar_height() {


### PR DESCRIPTION
When praying with psalms, it is easy to "get lost" and forget the current verse. A good helper could be to "mark" the current verse.

Technically, this proposition used the ":focus" CSS pseudo class to display a red line on the left of the current verse.

This PR also make the "antienne" word bold. Not sure if this is the best idea however.

Here is a visual example:

![20190216_121217](https://user-images.githubusercontent.com/739985/52898940-6fd44e80-31e4-11e9-8aae-b5a32a98f94e.jpg)
