### PR TITLE
[core] improve fullscreen toggle UX

### DIFF
--- a/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
@@ -38,6 +38,7 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 
@@ -257,6 +258,18 @@ public class LecturesActivity extends AppCompatActivity implements
                 }
             }
         });
+
+        // Add some padding at the bottom of the drawer to account for the navigation bar
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
+            drawerView.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
+                @Override
+                public WindowInsets onApplyWindowInsets(View view, WindowInsets windowInsets) {
+                    View navigationMenuView = findViewById(R.id.design_navigation_view);
+                    navigationMenuView.setPaddingRelative(0, 0, 0, windowInsets.getSystemWindowInsetBottom());
+                    return windowInsets.consumeSystemWindowInsets();
+                }
+            });
+        }
 
         // Task switcher color for Android >= 21
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
@@ -343,8 +343,18 @@ public class LecturesActivity extends AppCompatActivity implements
         // Some users wants complete full screen, no status bar at all. This is NOT compatible with multiwindow mode / non focused
         boolean hideStatusBar = settings.getBoolean(SyncPrefActivity.KEY_PREF_DISP_FULLSCREEN, false) && !isMultiWindow;
 
+        // Detect orientation
         Display getOrient = getWindowManager().getDefaultDisplay();
         boolean is_portrait = getOrient.getRotation() == Surface.ROTATION_0 || getOrient.getRotation() == Surface.ROTATION_180;
+
+        // Guess the device type
+        Configuration cfg = getResources().getConfiguration();
+        boolean is_tablet = cfg.smallestScreenWidthDp >= 600;
+
+        // Guess navigation bar location (bottom or side)
+        boolean has_bottom_navigation_bar = is_portrait || is_tablet;
+
+        // Build UI options
         int uiOptions = 0;
 
         // When the user wants fullscreen, always hide the status bar, even after a "tap"
@@ -363,7 +373,7 @@ public class LecturesActivity extends AppCompatActivity implements
             uiOptions |= View.SYSTEM_UI_FLAG_LOW_PROFILE;
 
             // Translucent bar, *ONLY* in portrait mode (broken in landscape)
-            if (is_portrait) {
+            if (has_bottom_navigation_bar) {
                 uiOptions |= View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
             }
             if (Build.VERSION.SDK_INT >= 19) {
@@ -373,7 +383,7 @@ public class LecturesActivity extends AppCompatActivity implements
 
         // Translucent bar, *ONLY* in portrait mode (broken in landscape)
         if (Build.VERSION.SDK_INT >= 19) {
-            if (is_portrait && !isMultiWindow) {
+            if (has_bottom_navigation_bar && !isMultiWindow) {
                 window.addFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
             } else  {
                 window.clearFlags(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
@@ -381,7 +391,7 @@ public class LecturesActivity extends AppCompatActivity implements
 
             // Compensate status bar height in full screen, with visible toolbar, on portrait mode
             // or some specific versions in landscape too.
-            if (!isMultiWindow && !hideStatusBar && (is_portrait || Build.VERSION.SDK_INT < 21)) {
+            if (!isMultiWindow && !hideStatusBar && (has_bottom_navigation_bar || Build.VERSION.SDK_INT < 21)) {
                 toolbar.setPadding(0, get_status_bar_height(), 0, 0);
             } else {
                 // When switching between modes, reset height


### PR DESCRIPTION
We we added the fullscreen mode by default, a major concern was to let
an easy way out of fullscreen mode without cluttering the interface. For
this reason, we added a 'catch all' tap event listener that toggled
fullscreen mode on tap event.

This approaches has a number of drawbacks in a *touch* based interface,
and the fullscreen mode was entered and exited far too frequently. This
is even more visible with the PR on the current verse highlight where
each tap triggers a fullscreen toggle.

This commit is an attempt to fix this while retaining an easily
discoverable exit path.

It completely removes the 'catch all' event listener and insteads binds
the the drawer open/close events. This makes sense since opening the
drawer is part of the 'navigation' intent.

Of course, the usual Android way to display the navigation bar by sliding
from the bottom of the screen remains active.