### PR TITLE
[bible] fix back button behavior

### DIFF
--- a/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
@@ -39,6 +39,7 @@ import static co.epitre.aelf_lectures.SyncPrefActivity.KEY_BIBLE_LAST_PAGE;
 public class SectionBibleFragment extends SectionFragmentBase {
     public static final String TAG = "SectionBibleFragment";
     public static final String BASE_RES_URL = "file:///android_asset/www/";
+    public static final String INDEX_URL = BASE_RES_URL+"index.html";
 
     public SectionBibleFragment(){
         // Required empty public constructor
@@ -129,7 +130,7 @@ public class SectionBibleFragment extends SectionFragmentBase {
             // Load default page
             SharedPreferences settings = getActivity().getPreferences(Context.MODE_PRIVATE);
             Log.d(TAG,"Loading webview, KEY_BIBLE_LAST_PAGE is " + settings.getString(KEY_BIBLE_LAST_PAGE,"null"));
-            mWebView.loadUrl(settings.getString(KEY_BIBLE_LAST_PAGE,(BASE_RES_URL + "index.html")));
+            mWebView.loadUrl(settings.getString(KEY_BIBLE_LAST_PAGE, INDEX_URL));
         }
 
         //Save last URL
@@ -161,12 +162,14 @@ public class SectionBibleFragment extends SectionFragmentBase {
      */
     @Override
     public boolean onBackPressed() {
-        if (mWebView.canGoBack()) {
-            mWebView.goBack();
-            return true;
-        } else {
+        // If the current page is the index, do the default action.
+        if (mWebView.getUrl().equals(INDEX_URL)) {
             return false;
         }
+
+        // Go back to the index
+        mWebView.loadUrl(INDEX_URL);
+        return true;
     }
 
     @Override


### PR DESCRIPTION
When the "bible" section restores the last viewed URL, it does not
restore the history. When a user presses the "back" button, the
application exits instead of going back to the main bible page.

This commit proposes a different behavior:
- If the current page is the index, we exit as before
- In all other cases, we load the index page

This is a poor man state machine...