### PR TITLE
[bible] add max width for the offices

### DIFF
--- a/app/src/main/res/layout-sw600dp/fragment_lecture.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_lecture.xml
@@ -1,0 +1,43 @@
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".LecturesActivity$DummySectionFragment" >
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/LectureSwipeRefresh"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
+
+            <Space
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+
+            <WebView
+                android:id="@+id/LectureView"
+                android:layout_width="450dp"
+                android:layout_height="match_parent"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentBottom="true"
+                android:layout_centerInParent="true"
+                android:layout_centerHorizontal="true"
+                android:layout_centerVertical="true"
+                android:background="?attr/colorLectureBackground" />
+
+            <Space
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1" />
+        </LinearLayout>
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+</RelativeLayout>


### PR DESCRIPTION
On a big tablet screen, the office are not pleasant to read. Most text
is moved far on the left whereas most of the UI is centered.

To make the display nicer on tablets, the width is set to 500dp. The
layout system will then either reduce the size to fit the available
screen, either insert blank spaces on both sides thus centering the
view.

Here area 2 screenshots of the result on my tablet:
![screenshot_20190216-213506_aelf - lectures du jour](https://user-images.githubusercontent.com/739985/52904941-06c7f780-3233-11e9-88ed-005397ec8355.jpg)
![screenshot_20190216-213433_aelf - lectures du jour](https://user-images.githubusercontent.com/739985/52904942-07608e00-3233-11e9-87fe-4d0b037f65e3.jpg)
