### PR TITLE
Fix a couple of NullPointerException instances

### DIFF
--- a/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
@@ -524,7 +524,7 @@ public class LecturesActivity extends AppCompatActivity implements
             try {
                 sectionOfficeFragment = (SectionOfficesFragment) sectionFragment;
                 sectionOfficeFragment.loadLecture(what);
-            } catch (ClassCastException e) {
+            } catch (ClassCastException|NullPointerException e) {
                 sectionOfficeFragment = new SectionOfficesFragment();
                 Bundle arguments = new Bundle();
                 arguments.putInt("what", what.getPosition());
@@ -571,9 +571,8 @@ public class LecturesActivity extends AppCompatActivity implements
     public boolean dispatchTouchEvent(MotionEvent event) {
         try {
             return super.dispatchTouchEvent(event);
-        } catch (IndexOutOfBoundsException e) {
+        } catch (IndexOutOfBoundsException|NullPointerException e) {
             // Ignore: most likely caused because the app is loading and the pager view is not yet ready
-            // but still forward to sentry as I'd rather be sure.
         }
         return false; // Fallback: consider event as not consumed
     }

--- a/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
@@ -1,5 +1,6 @@
 package co.epitre.aelf_lectures;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -112,13 +113,22 @@ public class SectionBibleFragment extends SectionFragmentBase {
             @Override
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(mWebView, url);
+
+                Activity activity = getActivity();
+                if (activity == null) {
+                    return;
+                }
+
+                SharedPreferences settings = activity.getPreferences(Context.MODE_PRIVATE);
+                if (settings == null) {
+                    return;
+                }
+
                 String last_url = mWebView.getUrl();
                 Log.d(TAG, "last_url is " + last_url);
-                SharedPreferences settings = getActivity().getPreferences(Context.MODE_PRIVATE);
                 SharedPreferences.Editor editor = settings.edit();
                 editor.putString(KEY_BIBLE_LAST_PAGE, last_url);
                 editor.apply();
-                Log.d(TAG,"onPageFinished, KEY_BIBLE_LAST_PAGE is " + settings.getString(KEY_BIBLE_LAST_PAGE,"null"));
 
             }
             //TODO: Save scroll position and restore it.

--- a/app/src/main/java/co/epitre/aelf_lectures/SectionOfficesFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionOfficesFragment.java
@@ -1,5 +1,6 @@
 package co.epitre.aelf_lectures;
 
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
@@ -630,7 +631,10 @@ public class SectionOfficesFragment extends SectionFragmentBase implements
                 break;
             case LOAD_FAIL:
                 setLoading(false);
-                Toast.makeText(getContext(), "Oups... Impossible de rafraîchir.", Toast.LENGTH_SHORT).show();
+                Context context = getContext();
+                if(context != null) {
+                    Toast.makeText(context, "Oups... Impossible de rafraîchir.", Toast.LENGTH_SHORT).show();
+                }
                 break;
             case LOAD_DONE:
                 setLoading(false);


### PR DESCRIPTION
Nothing terrible or out of the ordinary. Only a couple of strange-looking NullPointerExceptions which are probably related to the application being stopped at the same time an event is asynchronously propagated.

It would be great if you could test it on our phone for a bit of time to make sure there is no additional regression, then I'll port it to the 2.0 maintenance branch.