### PR TITLE
Add night mode toggle to menu

### DIFF
--- a/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
@@ -99,11 +99,16 @@ public class LecturesActivity extends AppCompatActivity implements
      */
     SectionFragmentBase sectionFragment;
 
+    /**
+     * Theme
+     */
+    Boolean nightMode = false;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         // Install theme before anything else
         settings = PreferenceManager.getDefaultSharedPreferences(this);
-        Boolean nightMode = settings.getBoolean(SyncPrefActivity.KEY_PREF_DISP_NIGHT_MODE, false);
+        nightMode = settings.getBoolean(SyncPrefActivity.KEY_PREF_DISP_NIGHT_MODE, false);
         this.setTheme(nightMode ? R.style.AelfAppThemeDark : R.style.AelfAppThemeLight);
 
         // Restore state
@@ -475,6 +480,15 @@ public class LecturesActivity extends AppCompatActivity implements
         return do_manual_sync("manual");
     }
 
+    public boolean onToggleNightMode() {
+        // Toggle the value
+        nightMode = !nightMode;
+        SharedPreferences.Editor editor = settings.edit();
+        editor.putBoolean(SyncPrefActivity.KEY_PREF_DISP_NIGHT_MODE, nightMode);
+        editor.apply();
+        return true;
+    }
+
     public boolean onApplyOptimalSyncSettings() {
         SharedPreferences.Editor editor = settings.edit();
 
@@ -547,6 +561,7 @@ public class LecturesActivity extends AppCompatActivity implements
     public boolean onCreateOptionsMenu(Menu menu) {
         // Inflate the menu; this adds items to the action bar
         getMenuInflater().inflate(R.menu.toolbar_main, menu);
+        menu.findItem(R.id.action_toggle_night_mode).setChecked(nightMode);
         return true;
     }
 
@@ -563,6 +578,8 @@ public class LecturesActivity extends AppCompatActivity implements
                 return onSyncPref();
             case R.id.action_sync_do:
                 return onSyncDo();
+            case R.id.action_toggle_night_mode:
+                return onToggleNightMode();
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
@@ -218,6 +218,22 @@ public class SectionBibleFragment extends SectionFragmentBase {
     }
 
     //
+    // API
+    //
+
+    public Uri getUri() {
+        // Get current webview URL
+        String webviewUrl = mWebView.getUrl();
+        webviewUrl = webviewUrl.substring(BASE_RES_URL.length() - 1, webviewUrl.length()- ".html".length());
+        if (webviewUrl.equals("/index")) {
+            webviewUrl = "/bible";
+        }
+
+        // Get and return the Uri
+        return Uri.parse("https://www.aelf.org" + webviewUrl);
+    }
+
+    //
     // Events
     //
 
@@ -226,12 +242,8 @@ public class SectionBibleFragment extends SectionFragmentBase {
             return false;
         }
 
-        // Get current webview URL
-        String webviewUrl = mWebView.getUrl();
-        webviewUrl = webviewUrl.substring(BASE_RES_URL.length() - 1, webviewUrl.length()- ".html".length());
-        if (webviewUrl.equals("/index")) {
-            webviewUrl = "/bible";
-        }
+        // Get current URL
+        String webviewUrl = getUri().toString();
 
         // Get current webview title
         String webviewTitle = mWebView.getTitle();

--- a/app/src/main/java/co/epitre/aelf_lectures/SectionFragmentBase.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionFragmentBase.java
@@ -39,6 +39,12 @@ public abstract class SectionFragmentBase extends Fragment {
     }
 
     //
+    // Callback
+    //
+
+    public abstract Uri getUri();
+
+    //
     // Events
     //
 

--- a/app/src/main/java/co/epitre/aelf_lectures/SectionOfficesFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionOfficesFragment.java
@@ -233,6 +233,30 @@ public class SectionOfficesFragment extends SectionFragmentBase implements
     }
 
     //
+    // API
+    //
+
+    public Uri getUri() {
+        // Make sure we DO have something to share
+        // FIXME: racy, the loader will update it and it's in a thread
+        if (lecturesPagerAdapter == null || mViewPager == null) {
+            return null;
+        }
+
+        // Get current lecture
+        int position = mViewPager.getCurrentItem();
+        LectureItem lecture = lecturesPagerAdapter.getLecture(position);
+
+        // Build URL
+        String url = "http://www.aelf.org/"+whatwhen.when.toIsoString()+"/romain/"+whatwhen.what.aelfUrlName();
+        if (lecture.key != null) {
+            url += "#"+lecture.key;
+        }
+
+        return Uri.parse(url);
+    }
+
+    //
     // Lifecycle
     //
 
@@ -413,15 +437,12 @@ public class SectionOfficesFragment extends SectionFragmentBase implements
             return false;
         }
 
-        // Get current position
+        // Get current lecture
         int position = mViewPager.getCurrentItem();
         LectureItem lecture = lecturesPagerAdapter.getLecture(position);
 
         // Build URL
-        String url = "http://www.aelf.org/"+whatwhen.when.toIsoString()+"/romain/"+whatwhen.what.aelfUrlName();
-        if (lecture.key != null) {
-            url += "#"+lecture.key;
-        }
+        String url = getUri().toString();
 
         // Build the data
         String prettyDate = whatwhen.when.toPrettyString();

--- a/app/src/main/java/co/epitre/aelf_lectures/SyncPrefActivity.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SyncPrefActivity.java
@@ -90,8 +90,6 @@ public class SyncPrefActivity extends PreferenceActivity implements OnSharedPref
             } else {
                 pref.setSummary("L'application fonctionne avec le serveur de test: "+server+". En cas de doute, vous pouvez effacer cette valeur sans danger.");
             }
-        } else if (key.equals(KEY_PREF_DISP_NIGHT_MODE)) {
-            recreate();
         }
 
         // Stop here is called with null preference pointer from the constructor

--- a/app/src/main/res/menu/toolbar_main.xml
+++ b/app/src/main/res/menu/toolbar_main.xml
@@ -4,6 +4,13 @@
     tools:context=".LecturesActivity">
 
     <item
+        android:id="@+id/action_toggle_night_mode"
+        android:checkable="true"
+        android:orderInCategory="200"
+        android:title="@string/action_toggle_night_mode"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_sync_settings"
         android:orderInCategory="200"
         app:showAsAction="never"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <!-- Toolbar buttons -->
     <string name="action_calendar">Date</string>
     <string name="action_share">Partager</string>
+    <string name="action_toggle_night_mode">Mode nuit</string>
     <string name="action_sync_settings">Paramètres</string>
     <string name="action_sync_do">Synchroniser</string>
     <string name="action_refresh">Rafraîchir</string>

--- a/app/src/main/res/xml/sync_preferences.xml
+++ b/app/src/main/res/xml/sync_preferences.xml
@@ -24,12 +24,6 @@
         android:summaryOff="@string/pref_disp_pull_to_refresh_off"
         android:summaryOn="@string/pref_disp_pull_to_refresh_on"
         android:title="@string/pref_disp_pull_to_refresh_title" />
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="pref_disp_night_mode"
-        android:summaryOff="@string/pref_disp_night_mode_off"
-        android:summaryOn="@string/pref_disp_night_mode_on"
-        android:title="@string/pref_disp_night_mode_title" />
     <PreferenceCategory android:title="@string/pref_section_sync_title" />
     <ListPreference 
         android:title="@string/pref_lectures_title"


### PR DESCRIPTION
The new night mode is hard to discover, hidden deep in the preference screens. Rather than making some advertising popup, we can move the theme toggle to the application menu.

At the same time, this PR enhances the theme transition with a cross-fade to make it nicer. As it turns out, the hard part in this case is not the fade itself but getting the application state to restore properly. This was done by 'recreate', but recreate does not support transitions.