### PR TITLE
Always display the navigation bar

### DIFF
--- a/app/src/main/java/co/epitre/aelf_lectures/LectureFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LectureFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -129,6 +130,14 @@ public class LectureFragment extends Fragment implements
         String color_text_bg = colorResourceToRgba(R.attr.colorLectureBackground);
         String color_text_fg = colorResourceToRgba(R.attr.colorLectureText);
 
+        // Compute navigation bar height
+        Resources resources = getContext().getResources();
+        int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+        int navigationBarHeight = 0;
+        if (resourceId > 0) {
+            navigationBarHeight = (int)(resources.getDimensionPixelSize(resourceId) / getResources().getDisplayMetrics().density);
+        }
+
         htmlString.append("<!DOCTYPE html>" +
                 "<html>" +
                     "<head>" +
@@ -136,6 +145,7 @@ public class LectureFragment extends Fragment implements
                         "<style type=\"text/css\">" +
                         "body{" +
                         "	margin:24px;" +
+                        "	margin-bottom:"+(24+navigationBarHeight)+"px;" +
                         "	background-color: "+color_text_bg+";" +
                         "   color: "+color_text_fg+";" +
                         "   font-family: sans-serif;" +

--- a/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/LecturesActivity.java
@@ -255,7 +255,7 @@ public class LecturesActivity extends AppCompatActivity implements
             }
         });
 
-        // Add some padding at the bottom of the drawer to account for the navigation bar
+        // Add some padding at the bottom of the drawer and content to account for the navigation bar
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH) {
             drawerView.setOnApplyWindowInsetsListener(new View.OnApplyWindowInsetsListener() {
                 @Override
@@ -376,7 +376,7 @@ public class LecturesActivity extends AppCompatActivity implements
             uiOptions |= View.SYSTEM_UI_FLAG_LOW_PROFILE;
 
             // Translucent bar, *ONLY* in portrait mode (broken in landscape)
-            if (has_bottom_navigation_bar) {
+            if (has_bottom_navigation_bar && hideStatusBar) {
                 uiOptions |= View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
             }
             if (Build.VERSION.SDK_INT >= 19) {

--- a/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
+++ b/app/src/main/java/co/epitre/aelf_lectures/SectionBibleFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
+import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Bundle;
@@ -107,6 +108,7 @@ public class SectionBibleFragment extends SectionFragmentBase {
 
                 return super.shouldInterceptRequest(view, url);
             }
+
             //Save last URL
             // onPageFinished infos found on https://stackoverflow.com/a/6720004
             @Override
@@ -120,6 +122,15 @@ public class SectionBibleFragment extends SectionFragmentBase {
                 editor.apply();
                 Log.d(TAG,"onPageFinished, KEY_BIBLE_LAST_PAGE is " + settings.getString(KEY_BIBLE_LAST_PAGE,"null"));
 
+                // Inject margin at the bottom to account for the navigation bar
+                Resources resources = getContext().getResources();
+                int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+                int navigationBarHeight = 0;
+                if (resourceId > 0) {
+                    navigationBarHeight = (int)(resources.getDimension(resourceId) / getResources().getDisplayMetrics().density);
+                }
+
+                mWebView.loadUrl("javascript:(function(){document.body.style.marginBottom = '"+navigationBarHeight+"px';})()");
             }
             //TODO: Save scroll position and restore it.
 

--- a/app/src/main/res/layout/activity_lectures.xml
+++ b/app/src/main/res/layout/activity_lectures.xml
@@ -23,6 +23,7 @@
         <!-- Main content -->
         <FrameLayout
             android:id="@+id/section_container"
+            android:background="?attr/colorLectureBackground"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 


### PR DESCRIPTION
We have users complaining that exiting the application is hard for them. This is related to the status bar being displayed only when the drawer menu is displayed.

The reason why we were hiding the navigation bar at first was to get back some screen real-estate and reduce the possible sources of distractions.

Since the navigation bar itself is not really a source of distraction and displaying it is standard even for all distraction free applications I know, we can display it all the time :)